### PR TITLE
Add header LittleFS.h

### DIFF
--- a/src/TJpg_Decoder.cpp
+++ b/src/TJpg_Decoder.cpp
@@ -294,8 +294,8 @@ JRESULT TJpg_Decoder::drawFsJpg(int32_t x, int32_t y, const String& pFilename) {
     Serial.println(F("Jpeg file not found"));
     return JDR_INP;
   }
+  return drawFsJpg(x, y, SPIFFS.open( pFilename, "r"));
 #endif
-    return drawFsJpg(x, y, SPIFFS.open( pFilename, "r"));
 }
 
 /***************************************************************************************

--- a/src/TJpg_Decoder.h
+++ b/src/TJpg_Decoder.h
@@ -20,12 +20,16 @@ https://github.com/Bodmer/TJpg_Decoder
   #if defined (ESP8266) || defined (ESP32)
     #include <pgmspace.h>
 
-    #define TJPGD_LOAD_SPIFFS
-    #define FS_NO_GLOBALS
-    #include <FS.h>
+    #ifdef USE_LITTLEFS
+      #include <LittleFS.h>
+    #else
+      #define TJPGD_LOAD_SPIFFS
+      #define FS_NO_GLOBALS
+      #include <FS.h>
 
-    #ifdef ESP32
-      #include "SPIFFS.h" // ESP32 only
+      #ifdef ESP32
+        #include "SPIFFS.h" // ESP32 only
+      #endif
     #endif
   #endif
 

--- a/src/TJpg_Decoder.h
+++ b/src/TJpg_Decoder.h
@@ -21,7 +21,15 @@ https://github.com/Bodmer/TJpg_Decoder
     #include <pgmspace.h>
 
     #ifdef USE_LITTLEFS
-      #include <LittleFS.h>
+      #ifdef ESP8266
+        #include <LittleFS.h>
+      #endif
+      #ifdef ESP32
+        #include <FS.h>
+
+        #define LittleFS LITTLEFS
+        #include <LITTLEFS.h>
+      #endif
     #else
       #define TJPGD_LOAD_SPIFFS
       #define FS_NO_GLOBALS


### PR DESCRIPTION
Note: to use any of file system functions in the sketch, add the
following include to the sketch:

//#include "FS.h" // SPIFFS is declared
#include "LittleFS.h" // LittleFS is declared

**SDFS and SD**

FAT filesystems are supported on the ESP8266 using the old Arduino
wrapper “SD.h” which wraps the “SDFS.h” filesystem transparently.

Any commands discussed below pertaining to SPIFFS or LittleFS are
applicable to SD/SDFS.

For legacy applications, the classic SD filesystem may continue to
be used, but for new applications, directly accessing the SDFS
filesystem is recommended as it may expose additional functionality
that the old Arduino SD filesystem didn’t have.

Note that in earlier releases of the core, using SD and SPIFFS in
the same sketch was complicated and required the use of NO_FS_GLOBALS.
The current design makes SD, SDFS, SPIFFS, and LittleFS fully source
compatible and so please remove any NO_FS_GLOBALS definitions in your
projects when updgrading core versions.

https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html