### PR TITLE
fix grayscale output

### DIFF
--- a/src/tjpgd.c
+++ b/src/tjpgd.c
@@ -850,7 +850,8 @@ static JRESULT mcu_output (
 					if (mx == 16) {					/* Double block width? */
 						if (ix == 8) py += 64 - 8;	/* Jump to next block if double block height */
 					}
-					*pix++ = (uint8_t)*py++;			/* Get and store a Y value as grayscale */
+					int yy = *py++;
+					*pix++ = BYTECLIP(yy);			/* Get and store a Y value as grayscale */
 				}
 			}
 		}


### PR DESCRIPTION
This fix enables the acquisition of Y for JD_FORMAT = 2 (output in grayscale). The usage for this format is as follows:

In tjpgd.h
JD_FORMAT = 2

In main.c
tft_output_callback(int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t *bitmap)
{
uint8_t *pixels_array = (uint8_t *) bitmap;
....
}